### PR TITLE
Fix account creation date display

### DIFF
--- a/cmd/n26/n26.go
+++ b/cmd/n26/n26.go
@@ -104,7 +104,7 @@ func main() {
 				} else {
 					data := [][]string{
 						{
-							time.Unix(status.Created, 0).String(),
+							time.Unix(status.Created/1000, 0).String(),
 						},
 					}
 					NewTableWriter().WriteData([]string{"Created"}, data)


### PR DESCRIPTION
PR related to #16 

The value is reported in milliseconds by the API and time.Unix expects seconds, thus printing creation dates far off in the future.

