### PR TITLE
Adjust basic auth header.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -22,7 +22,7 @@ func createRequest(path, deviceToken string, body io.Reader) (*http.Request, err
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Basic YW5kcm9pZDpzZWNyZXQ=")
+	req.Header.Set("Authorization", "Basic bmF0aXZld2ViOg==")
 	req.Header.Set("device-token", deviceToken)
 	return req, nil
 }


### PR DESCRIPTION
I’m not quite sure why this is needed, but everything stopped working with 401 errors everywhere. I snarfed this key from some other N26 project, so if these need to be unique per project, please let me know.