### PR TITLE
Adding tzdata package to Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ FROM alpine
 
 COPY --from=build-env /go/bin/n26 /
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates tzdata
 
 ENTRYPOINT [ "/n26" ]


### PR DESCRIPTION
When performing a `transaction` request n26 does some timestamp modification to make the timestamp relevant to the user's timezone. This operation requires certain files be in place to resolve the "Europe/Berlin" timezone.  If they are absent [this issue](https://github.com/guitmz/n26/issues/26) arises.

On Alpine Image these files are provided by the `tzdata` package.  Adding this package in the n26 `Dockerfile` fixes the issue.